### PR TITLE
bump versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "wrapper"
   ],
   "dependencies": {
-    "gridfs-stream": "0.5.3"
+    "gridfs-stream": "^0.5.3"
   },
   "devDependencies": {
     "chai": "1.10.0",
-    "mongodb": "1.4.x"
+    "mongodb": "^2.0.31"
   },
   "author": "Lewis J Ellis",
   "license": "MIT",


### PR DESCRIPTION
as noted in https://github.com/aheckmann/gridfs-stream/issues/74 this library remains functional, but loading an old version of gridfs-stream with mongodb@2 breaks stuff
