### PR TITLE
streams2 fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,17 @@ function streamToBuffer(source, cb) {
   var chunks = [];
   var buffer = new stream.Writable();
 
-  buffer._write = function (chunk) {
+  buffer._write = function (chunk, enc, cb) {
     chunks.push(chunk);
+    cb();
   };
 
   source.on('end', function () {
     cb(null, Buffer.concat(chunks));
+  });
+
+  source.on('error', function (err) {
+    cb(err);
   });
 
   source.pipe(buffer);

--- a/index.js
+++ b/index.js
@@ -33,6 +33,10 @@ Grid.prototype.fromFile = function (options, source) {
         return cb(null, file);
       });
 
+      ws.on('error', function (err) {
+        cb(err);
+      });
+
       rs.pipe(ws);
     }
   };
@@ -56,6 +60,10 @@ Grid.prototype.readFile = function (options, cb) {
 Grid.prototype.writeFile = function (options, data, cb) {
   data = typeof data === 'object' ? data.toString() : data;
   var ws = this.createWriteStream(options);
+
+  ws.on('error', function (err) {
+    cb(err);
+  });
 
   ws.on('close', function (file) {
     cb(null, file);

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "wrapper"
   ],
   "dependencies": {
-    "gridfs-stream": "0.5.3"
+    "gridfs-stream": "^1.1.1"
   },
   "devDependencies": {
-    "chai": "1.10.0",
-    "mongodb": "1.4.x"
+    "chai": "2",
+    "mongodb": "2"
   },
   "author": "Lewis J Ellis",
   "license": "MIT",


### PR DESCRIPTION
as noted in https://github.com/aheckmann/gridfs-stream/issues/74 is loading an old version of gridfs-stream with mongodb@2 breaks stuff

there were some additional things to be done as well. with streams2, the callback needs to be called on the `_write` function. this prevented readFile from being called in some cases. also, errors were not handled.

now that I think about it, I guess the only mongo-2 fixes was just bumping the version... whatever :)
cheers
